### PR TITLE
feat(action): add GitHub Action for installing and caching APT tools

### DIFF
--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -1,0 +1,61 @@
+name: apt-tools test
+
+on:
+  pull_request:
+    paths:
+      - actions-use-apt-tools/**
+  workflow_dispatch:
+
+jobs:
+  initial:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./actions-use-apt-tools
+        id: action
+        with:
+          cache: workflow
+          tools: bmake
+          method: timestamp
+      - run: (cd actions-use-apt-tools/__test__; . run.sh )
+      - run: test "${{ steps.action.outputs.cache-hit }}" != true
+  cached:
+    needs: initial
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./actions-use-apt-tools
+        id: action
+        with:
+          cache: workflow
+          tools: bmake
+          method: timestamp
+      - run: (cd actions-use-apt-tools/__test__; . run.sh )
+      - run: test "${{ steps.action.outputs.cache-hit }}" == true
+  no-cache:
+    needs: initial
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./actions-use-apt-tools
+        id: action
+        with:
+          cache: no
+          tools: bmake
+          method: timestamp
+      - run: (cd actions-use-apt-tools/__test__; . run.sh )
+      - run: test "${{ steps.action.outputs.cache-hit }}" != true
+  key:
+    needs: initial
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./actions-use-apt-tools
+        id: action
+        with:
+          cache: workflow
+          tools: bmake
+          method: timestamp
+          key: v2
+      - run: (cd actions-use-apt-tools/__test__; . run.sh )
+      - run: test "${{ steps.action.outputs.cache-hit }}" != true

--- a/actions-use-apt-tools/README.md
+++ b/actions-use-apt-tools/README.md
@@ -1,0 +1,104 @@
+# actions-use-apt-tools
+
+From [tecolicom/actions-use-apt-tools](https://github.com/tecolicom/actions-use-apt-tools)
+
+![actions-use-apt-tools](https://github.com/tecolicom/actions-use-apt-tools/actions/workflows/test.yml/badge.svg)
+
+This GitHub action installs Linux APT packages and cache them for later
+use. When executed next time with same package list, and any other
+environment are not changed, installed files are extracted from the
+cached archive.
+
+When valid cached archive is not found, all packages are installed by
+`apt-get` command. If you want partial install/cache behavior, use
+this action multiple times.
+
+There are two different methods to identify installed files. Default
+is **package** method, and files are taken by `dpkg -L` command. This
+method runs very fast. For packages generate files during
+installation, use **timestamp** method, and all files those have newer
+timestamp are cached. Files are searched under /etc,
+/usr/{bin,sbin,lib,share} and /var/lib directory. Search directories
+can be given by **path** parameter.
+
+Output is same as [`@actions/cache`](https://github.com/actions/cache).
+
+## Usage
+
+```yaml
+# inputs:
+#   tools:  { required: true,  type: string }
+#   repos:  { required: false, type: string }
+#   cache:  { required: false, type: string, default: yes }
+#   key:    { required: false, type: string }
+#   method: { required: false, type: string, default: package }
+#   path:   { required: false, type: string,
+#             default: "/etc /usr/bin /usr/sbin /usr/lib /usr/share /var/lib" }
+
+- uses: tecolicom/actions-use-apt-tools@v1
+  with:
+    # apt packages
+    tools: ""
+
+    # additional repositories
+    repos: ""
+
+    # Cache strategy
+    #
+    # yes:      activate cache
+    # no:       no cache
+    # workflow: effective within same workflow (mainly for test)
+    #
+    cache: yes
+
+    # Additional cache key
+    key: ""
+
+    # Method to idenfity installed files
+    #   package:   use "dpkg -L" command output
+    #   timestamp: use file's timestamps to check update
+    method: package
+
+    # Search path with "timestamp" method
+    path: ""
+```
+
+## Example
+
+### Normal case with default _package_ method
+
+```yaml
+- uses: tecolicom/actions-use-apt-tools@v1
+  with:
+    tools: bmake
+```
+
+### Using _timestamp_ method
+
+For packages which generates additional files other than included in
+package during installation, use _timestamp_ method. If you know
+where they will be placed, provide them by a _path_ parameter.
+
+```yaml
+- uses: tecolicom/actions-use-apt-tools@v1
+  with:
+    tools: mecab mecab-ipadic mecab-ipadic-utf8
+    method: timestamp
+```
+
+### With additional repositories
+
+```yaml
+- uses: tecolicom/actions-use-apt-tools@v1
+  id: action
+  with:
+    repos: ppa:ubuntu-toolchain-r/test
+    tools: g++-11
+    method: timestamp
+```
+
+## See Also
+
+### [tecolicom/actions](https://github.com/tecolicom/actions)
+
+### [add-apt-repository](https://manpages.ubuntu.com/manpages/trusty/man1/add-apt-repository.1.html)

--- a/actions-use-apt-tools/__test__/hello/Makefile
+++ b/actions-use-apt-tools/__test__/hello/Makefile
@@ -1,0 +1,2 @@
+all:
+	@echo Hello World

--- a/actions-use-apt-tools/__test__/run.sh
+++ b/actions-use-apt-tools/__test__/run.sh
@@ -1,0 +1,2 @@
+set -x
+(cd hello; bmake)

--- a/actions-use-apt-tools/action.yaml
+++ b/actions-use-apt-tools/action.yaml
@@ -1,0 +1,123 @@
+name: install-and-cache apt tools
+description: 'GitHub Action to install and cache apt tools'
+author: 'Office TECOLI, LLC'
+branding:
+  color: orange
+  icon: type
+
+inputs:
+  tools: {required: true, type: string}
+  repos: {required: false, type: string}
+  cache: {required: false, type: string, default: yes}
+  key: {required: false, type: string}
+  method: {required: false, type: string, default: package}
+  path:
+    required: false
+    type: string
+    default: >-
+      /etc
+      /usr/bin
+      /usr/sbin
+      /usr/lib
+      /usr/share
+      /var/lib
+
+outputs:
+  cache-hit:
+    value: ${{ steps.cache.outputs.cache-hit }}
+
+runs:
+  using: composite
+  steps:
+
+    - id: setup
+      shell: bash
+      run: |
+        : setup use-apt-tools
+        case "${{ inputs.cache }}" in
+            yes|workflow) cache="${{ inputs.cache }}" ;;
+            *)            cache=no ;;
+        esac
+        action_key="v0.2"
+        given_key="${{ inputs.key }}"
+        method="${{ inputs.method }}"
+        tools="${{ inputs.tools }}"
+        hash=$( (uname -mrsv; echo $method $tools) | (md5sum||md5) | awk '{print $1}' )
+        key="${action_key:+$action_key-}$hash${given_key:+-$given_key}"
+        [ "$cache" == 'workflow' ] && \
+            key+="-${{ github.run_id }}-${{ github.run_attempt }}"
+        sed 's/^ *//' << END >> $GITHUB_OUTPUT
+            cache=$cache
+            archive=$HOME/apt-$hash.tz
+            key=$key
+        END
+
+    - id: cache
+      if: steps.setup.outputs.cache != 'no'
+      uses: actions/cache@v4
+      with:
+        path: ${{ steps.setup.outputs.archive }}
+        key: ${{ steps.setup.outputs.key }}
+
+    - id: extract
+      if: steps.setup.outputs.cache != 'no' && steps.cache.outputs.cache-hit == 'true'
+      shell: bash
+      run: |
+        : extract
+        archive="${{ steps.setup.outputs.archive }}"
+        ls -l $archive
+        [ -f $archive ] && sudo tar -C / -xvzf $archive
+
+    - id: update
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        : update
+        for repo in ${{ inputs.repos }}
+        do
+            sudo add-apt-repository -y $repo
+        done
+        sudo apt-get update
+
+    - id: install-and-archive
+      if: >-
+        inputs.method == 'timestamp' &&
+        steps.setup.outputs.cache != 'no' &&
+        steps.cache.outputs.cache-hit != 'true'
+      uses: tecolicom/actions-install-and-archive@v1
+      with:
+        run: apt-get install -y ${{ inputs.tools }}
+        archive: ${{ steps.setup.outputs.archive }}
+        path: ${{ inputs.path }}
+        sudo: true
+
+    - id: self-install
+      if: >-
+        steps.setup.outputs.cache == 'no' ||
+        (inputs.method == 'package' && steps.cache.outputs.cache-hit != 'true')
+      shell: bash
+      run: |
+        : self install
+        sudo apt-get install -y ${{ inputs.tools }}
+
+    - id: self-archive
+      if: >-
+        steps.setup.outputs.cache != 'no' &&
+        (inputs.method == 'package' && steps.cache.outputs.cache-hit != 'true')
+      shell: bash
+      run: |
+        : archive
+        tools="${{ inputs.tools }}"
+        archive="${{ steps.setup.outputs.archive }}"
+        list=/tmp/dpkg.out
+        dpkg -L $tools | while read f
+        do
+            [ -d "$f" ] && continue
+            if [ -e "$f" ]
+            then echo "$f"
+            else echo "not found: $f" >&2
+            fi
+        done > $list
+        perl -i -pe s:^/:: $list
+        tar -cvzf $archive -C / -T $list
+        ls -l $archive


### PR DESCRIPTION
This commit introduces a new GitHub Action that allows users to install
and cache APT tools. The action supports various inputs for tools,
repositories, caching strategies, and methods for identifying installed
files. It also includes detailed usage instructions in the README.

--- commit logs ---
* feat(action): add GitHub Action for installing and caching APT tools
This commit introduces a new GitHub Action that allows users to install
and cache APT tools. The action supports various inputs for tools,
repositories, caching strategies, and methods for identifying installed
files. It also includes detailed usage instructions in the README.



* fix(deps): update dependency @types/node to v22.15.18
This commit updates the `@types/node` package to version `22.15.18`, ensuring compatibility with the latest TypeScript definitions.


