### PR TITLE
feat(action): add install-and-archive GitHub Action

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -1,0 +1,35 @@
+name: cache test
+
+on:
+  pull_request:
+    paths:
+      - actions-install-and-archive/**
+  workflow_dispatch:
+
+jobs:
+  initial:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./actions-install-and-archive
+        id: action
+        with:
+          run: |
+            apt-get update
+            apt list --installed | grep -i mecab
+            for pkg in mecab mecab-ipadic-utf8 libmecab-dev
+            do
+                apt-get reinstall -qq $pkg
+            done
+          archive: /tmp/apt-archive.tz
+          sudo: true
+          path: >-
+            /etc
+            /usr/bin
+            /usr/sbin
+            /usr/lib
+            /usr/share
+            /var/lib
+      - run: |
+          mecab --version
+          echo 吾輩は猫である | mecab

--- a/actions-install-and-archive/README.md
+++ b/actions-install-and-archive/README.md
@@ -1,0 +1,67 @@
+# actions-install-and-archive
+
+From [tecolicom/actions-install-and-archive](https://github.com/tecolicom/actions-install-and-archive)
+
+![actions-install-and-archive](https://github.com/tecolicom/actions-install-and-archive/actions/workflows/test.yml/badge.svg)
+
+This GitHub action execute given script, and archive installed files.
+Before installation, an epoch file is made, and any files those have
+newer timestamp than this epoch file are archived.
+
+This is a backend action for other series of actions and not supposed
+to be used from normal workflow.
+
+## Usage
+
+```yaml
+# inputs:
+#   run:     { required: true,  type: string }
+#   archive: { required: false, type: string }
+#   path:    { required: false, type: string }
+#   list:    { required: false, type: string, default: "/tmp/updated-list" }
+#   sudo:    { required: false, type: boolean }
+#   verbose: { required: false, type: boolean, default: false }
+
+- uses: tecolicom/actions-install-and-archive@v1
+  with:
+    # install script
+    run: ""
+
+    # archive file
+    # if empty, do not archive
+    archive: ""
+
+    # install path
+    # multiple directories can be specified
+    # must start with /
+    path: ""
+
+    # sudo: run install script as root
+    sudo: false
+
+    # verbose: show verbose output
+    verbose: false
+```
+
+## Example
+
+```yaml
+- uses: tecolicom/actions-install-and-archive@v1
+  with:
+    run: apt-get install -qq mecab mecab-ipadic-utf8
+    archive: /tmp/apt-archive.tz
+    sudo: true
+    path: >-
+      /etc
+      /usr/bin
+      /usr/sbin
+      /usr/lib
+      /usr/share
+      /var/lib
+```
+
+## See Also
+
+### [tecolicom/actions](https://github.com/tecolicom/actions)
+
+### [tecolicom/actions-install-and-cache](https://github.com/tecolicom/actions-install-and-cache)

--- a/actions-install-and-archive/action.yaml
+++ b/actions-install-and-archive/action.yaml
@@ -1,0 +1,114 @@
+name: install-and-archive generic backend
+description: 'GitHub Action to run installer and archive result'
+author: 'Office TECOLI, LLC'
+branding:
+  color: orange
+  icon: type
+
+inputs:
+  run: {required: true, type: string}
+  archive: {required: false, type: string}
+  path: {required: true, type: string}
+  list: {required: false, type: string, default: "/tmp/updated-list"}
+  sudo: {required: false, type: string}
+  verbose: {required: false, type: string, default: false}
+
+runs:
+  using: composite
+  steps:
+
+    - id: setup
+      shell: bash
+      run: |
+        : setup install-and-archive
+        sed 's/^ *//' << END >> $GITHUB_OUTPUT
+            epoch=/tmp/epoch-$$
+        END
+
+    - id: install
+      shell: bash
+      run: |
+        : install
+        case "${{ inputs.sudo }}" in true|yes) sudo=sudo;; esac
+        define() { IFS='\n' read -r -d '' ${1} || true ; }
+        define script <<'EOS_cad8_c24e_'
+        ${{ inputs.run }}
+        EOS_cad8_c24e_
+        epoch="${{ steps.setup.outputs.epoch }}"
+        : ${epoch:?}
+        test "$script" != ''
+        touch $epoch && touch -A -01 $epoch &> /dev/null || sleep 0.1
+        ls -l $epoch
+        $sudo bash <<< "$script"
+
+    - id: archive
+      if: inputs.archive != ''
+      shell: bash
+      run: |
+        : archive
+        epoch="${{ steps.setup.outputs.epoch }}"
+        archive="${{ inputs.archive }}"
+        list=${{ inputs.list }}
+        verbose="${{ inputs.verbose }}"
+        paths="${{ inputs.path }}"
+        : ${epoch:?} ${archive:?} ${paths:?}
+        [ "$verbose" = true ] && set -x
+        if [ -f $epoch ]
+        then
+            cd /
+            > $list
+            exec 2>&1
+            for path in $paths
+            do
+                [[ ! "$path" =~ ^/ ]] && echo "$path does not start with /" && continue
+                [ -e "$path" ] || continue
+                echo "$path:"
+                # require sudo to avoid permission error
+                time sudo \
+                find $path \
+                    -not -type d \( -cnewer $epoch -o -newer $epoch \) -print \
+                    | tee -a $list \
+                    | awk '{ print } END { printf "%d files", NR }'
+            done
+            #
+            # remove dissmessed files
+            #
+            if [ -s $list ]
+            then
+                perl -i -lne '(-e) ? print : print STDERR' $list 2> /tmp/dismissed || :
+                if [ -s /tmp/dismissed ]
+                then
+                    echo dismissed: && cat /tmp/dismissed
+                fi
+            fi
+            #
+            # move symbolic links to the end of the list
+            #
+            if [ -s $list ]
+            then
+                perl -i -lne '(-l) ? do {push @s, $_; print STDERR} : print; do {print for @s} if eof' $list 2> /tmp/symlink
+                if [ -s /tmp/symlink ]
+                then
+                    echo "moved symlinks:" && cat /tmp/symlink
+                else
+                    echo "no symlinks"
+                    ls -l /tmp/symlink
+                fi
+            fi
+            #
+            # archive them
+            #
+            if [ -s $list ]
+            then
+                perl -i -pe s:^/:: $list
+                echo -n Archive $(wc -l < $list) files ...
+                time sudo tar -czf $archive -C / -T $list
+                ls -l $archive
+                [ "$verbose" = true ] && tar -tvzf $archive || :
+            else
+                echo "no updated file found."
+                > $archive
+            fi
+        else
+            echo $epoch not found
+        fi

--- a/actions-use-apt-tools/action.yaml
+++ b/actions-use-apt-tools/action.yaml
@@ -84,7 +84,7 @@ runs:
         inputs.method == 'timestamp' &&
         steps.setup.outputs.cache != 'no' &&
         steps.cache.outputs.cache-hit != 'true'
-      uses: tecolicom/actions-install-and-archive@v1
+      uses: shiron-dev/actions/actions-install-and-archive
       with:
         run: apt-get install -y ${{ inputs.tools }}
         archive: ${{ steps.setup.outputs.archive }}


### PR DESCRIPTION
This commit introduces a new GitHub Action for installing packages and archiving installed files. The action allows users to specify installation scripts, archive paths, and directories to monitor for changes. Detailed usage instructions are provided in the README.

--- commit logs ---
* feat(action): add install-and-archive GitHub Action
This commit introduces a new GitHub Action for installing packages and archiving installed files. The action allows users to specify installation scripts, archive paths, and directories to monitor for changes. Detailed usage instructions are provided in the README.


