### PR TITLE
fix(docs): update action references in README files

### DIFF
--- a/actions-install-and-archive/README.md
+++ b/actions-install-and-archive/README.md
@@ -22,7 +22,7 @@ to be used from normal workflow.
 #   sudo:    { required: false, type: boolean }
 #   verbose: { required: false, type: boolean, default: false }
 
-- uses: tecolicom/actions-install-and-archive@v1
+- uses: shiron-dev/actions/actions-install-and-archive@v1
   with:
     # install script
     run: ""
@@ -46,7 +46,7 @@ to be used from normal workflow.
 ## Example
 
 ```yaml
-- uses: tecolicom/actions-install-and-archive@v1
+- uses: shiron-dev/actions/actions-install-and-archive@v1
   with:
     run: apt-get install -qq mecab mecab-ipadic-utf8
     archive: /tmp/apt-archive.tz

--- a/actions-use-apt-tools/README.md
+++ b/actions-use-apt-tools/README.md
@@ -35,7 +35,7 @@ Output is same as [`@actions/cache`](https://github.com/actions/cache).
 #   path:   { required: false, type: string,
 #             default: "/etc /usr/bin /usr/sbin /usr/lib /usr/share /var/lib" }
 
-- uses: tecolicom/actions-use-apt-tools@v1
+- uses: shiron-dev/actions/actions-use-apt-tools@v1
   with:
     # apt packages
     tools: ""
@@ -68,7 +68,7 @@ Output is same as [`@actions/cache`](https://github.com/actions/cache).
 ### Normal case with default _package_ method
 
 ```yaml
-- uses: tecolicom/actions-use-apt-tools@v1
+- uses: shiron-dev/actions/actions-use-apt-tools@v1
   with:
     tools: bmake
 ```
@@ -80,7 +80,7 @@ package during installation, use _timestamp_ method. If you know
 where they will be placed, provide them by a _path_ parameter.
 
 ```yaml
-- uses: tecolicom/actions-use-apt-tools@v1
+- uses: shiron-dev/actions/actions-use-apt-tools@v1
   with:
     tools: mecab mecab-ipadic mecab-ipadic-utf8
     method: timestamp
@@ -89,7 +89,7 @@ where they will be placed, provide them by a _path_ parameter.
 ### With additional repositories
 
 ```yaml
-- uses: tecolicom/actions-use-apt-tools@v1
+- uses: shiron-dev/actions/actions-use-apt-tools@v1
   id: action
   with:
     repos: ppa:ubuntu-toolchain-r/test


### PR DESCRIPTION
Updated the action references in the README files for `actions-install-and-archive` and `actions-use-apt-tools` to point to the new repository location `shiron-dev/actions` instead of `tecolicom/actions`. This change ensures that users are directed to the correct source for the actions.

--- commit logs ---
* fix(docs): update action references in README files
Updated the action references in the README files for `actions-install-and-archive` and `actions-use-apt-tools` to point to the new repository location `shiron-dev/actions` instead of `tecolicom/actions`. This change ensures that users are directed to the correct source for the actions.


