### PR TITLE
fix(renovate): fix pnpm regex with multilineMatching and enable pinDigests

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,8 +10,9 @@
         "/action.yaml/"
       ],
       "matchStrings": [
-        "\"pnpm version\"\\s*default:\\s*\"(?<currentValue>.*)\""
+        "description: \"pnpm version\"[\\s\\S]*?default: \"(?<currentValue>[^\"]+)\""
       ],
+      "multilineMatching": true,
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "pnpm/pnpm",
       "extractVersionTemplate": "v(?<version>.*)"
@@ -24,5 +25,6 @@
       ],
       "semanticCommitType": "fix"
     }
-  ]
+  ],
+  "pinDigests": true
 }


### PR DESCRIPTION
## Summary

- pnpm `customManager` の regex に `multilineMatching: true` を追加し、`action.yaml` で `description` と `default` が別行にある場合でも正しく検出できるよう修正
- matchStrings の regex を実際の YAML 構造に合わせて修正
- `pinDigests: true` を追加し、`actions/setup-node@v6` を次回 Renovate 実行時に自動 SHA pin されるようにする

## Test plan

- [ ] Renovate dry-run で `pnpm/pnpm` の currentValue `10.34.3` が正しく検出されることを確認
- [ ] Renovate 実行後に `actions/setup-node@v6` が SHA pin された PR が作成されることを確認

https://claude.ai/code/session_01HjJYZ3XKcZ5YtkBrm7KSai

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjJYZ3XKcZ5YtkBrm7KSai)_

--- commit logs ---
* fix(renovate): fix pnpm regex with multilineMatching and enable pinDigests
- Add multilineMatching: true to pnpm customManager so the regex correctly
  matches the default value across multiple lines in action.yaml
- Fix matchStrings regex to match the actual YAML structure
- Add pinDigests: true so Renovate will SHA-pin actions/setup-node@v6

https://claude.ai/code/session_01HjJYZ3XKcZ5YtkBrm7KSai


