### PR TITLE
Update shiron-dev/actions/setup-node to v1.7.0

### DIFF
--- a/renovate-deps-comment/action.yml
+++ b/renovate-deps-comment/action.yml
@@ -19,7 +19,7 @@ runs:
   using: "composite"
   steps:
     - uses: actions/checkout@v6
-    - uses: shiron-dev/actions/setup-node@0cc65c3143f6a0d119fa8085c8b2ae3dd25e657b # v1.6.3
+    - uses: shiron-dev/actions/setup-node@0fb0711e97887ac23c78afe436fed5a4d6905133 # v1.7.0
       with:
         node-version: "24.11.0"
     - name: Dry-run Renovate


### PR DESCRIPTION
## Summary
Updates the `shiron-dev/actions/setup-node` action dependency to version v1.7.0.

## Changes
- Updated `shiron-dev/actions/setup-node` action from commit `0cc65c3143f6a0d119fa8085c8b2ae3dd25e657b` (v1.6.3) to `0fb0711e97887ac23c78afe436fed5a4d6905133` (v1.7.0)

## Details
This update brings the latest improvements and fixes from the v1.7.0 release of the setup-node action, which is used during the Renovate dry-run step in this workflow.

https://claude.ai/code/session_01TazAtXMWUj5d1yce76uFZL

--- commit logs ---
* fix(renovate-deps-comment): update setup-node SHA to pnpm v11 compatible version
The old SHA referenced setup-node with pnpm 10.31.0 as default, but renovate
now requires pnpm ^11.0.0. Update to the SHA that introduced pnpm 11.6.0.

https://claude.ai/code/session_01TazAtXMWUj5d1yce76uFZL


