### PR TITLE
[codex] use main for actions self references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
         working-directory: ./matrix-output-write
     steps:
       - uses: actions/checkout@v6
-      - uses: shiron-dev/actions/setup-node@0cc65c3143f6a0d119fa8085c8b2ae3dd25e657b # v1.6.3
+      - uses: shiron-dev/actions/setup-node@main
       - name: Run install
         run: |
           pnpm install --frozen-lockfile

--- a/actions-use-apt-tools/action.yaml
+++ b/actions-use-apt-tools/action.yaml
@@ -84,7 +84,7 @@ runs:
         inputs.method == 'timestamp' &&
         steps.setup.outputs.cache != 'no' &&
         steps.cache.outputs.cache-hit != 'true'
-      uses: shiron-dev/actions/actions-install-and-archive@0cc65c3143f6a0d119fa8085c8b2ae3dd25e657b # v1.6.3
+      uses: shiron-dev/actions/actions-install-and-archive@main
       with:
         run: apt-get install -y ${{ inputs.tools }}
         archive: ${{ steps.setup.outputs.archive }}

--- a/renovate-deps-comment/action.yml
+++ b/renovate-deps-comment/action.yml
@@ -19,7 +19,7 @@ runs:
   using: "composite"
   steps:
     - uses: actions/checkout@v6
-    - uses: shiron-dev/actions/setup-node@0cc65c3143f6a0d119fa8085c8b2ae3dd25e657b # v1.6.3
+    - uses: shiron-dev/actions/setup-node@main
       with:
         node-version: "24.11.0"
     - name: Dry-run Renovate


### PR DESCRIPTION
## Summary
- change internal shiron-dev/actions references from pinned release digests to `@main`
- keep external action references unchanged

## Why
The actions repository was pinning references to itself, so each actions release could trigger another Renovate digest update. Self-references should follow the repository main branch instead of release digests.

## Checks
- `actionlint .github/workflows/*.yml`
- YAML parse check for action/workflow files
- confirmed no pinned `shiron-dev/actions/...@<sha>` self-references remain

--- commit logs ---
* fix: use main for actions self references


