### PR TITLE
fix(renovate): remove invalid multilineMatching field

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,7 +12,6 @@
       "matchStrings": [
         "description: \"pnpm version\"[\\s\\S]*?default: \"(?<currentValue>[^\"]+)\""
       ],
-      "multilineMatching": true,
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "pnpm/pnpm",
       "extractVersionTemplate": "v(?<version>.*)"


### PR DESCRIPTION
## Summary
`customManagers[0].multilineMatching` は Renovate に存在しない無効なオプションで、
これが原因で renovate.json 全体が validation エラー（"Custom Manager contains
disallowed fields") になっていた。#391 で誤って追加されたもの。

複数行マッチは matchStrings の `[\s\S]` で既に実現できているため、このフィールドは
冗長かつ無効。削除しても pnpm バージョン検出の挙動は変わらない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- commit logs ---
* fix(renovate): remove invalid multilineMatching field
multilineMatching is not a valid Renovate custom manager option and made
the whole config fail validation. Cross-line matching is already handled
by the [\s\S] pattern in matchStrings, so the field is redundant.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FjtQsZEfN13u8Cz3ZT82yT


