### PR TITLE
feat: pin self references to the released version tag in the release PR

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -25,7 +25,7 @@
       "semanticCommitType": "fix"
     },
     {
-      "description": "Self references are bumped by the release workflow, not Renovate, to avoid a circular dependency.",
+      "description": "Self references are pinned to the released version tag by the release workflow (intentionally not digest pinned, since releases are immutable). Renovate must leave shiron-dev/actions alone to avoid a circular dependency.",
       "matchPackageNames": [
         "shiron-dev/actions"
       ],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
         working-directory: ./matrix-output-write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-      - uses: shiron-dev/actions/setup-node@84397408739dd8be5cab53d443ae764501063dab # v1.6.4
+      - uses: shiron-dev/actions/setup-node@v1.6.5
       - name: Run install
         run: |
           pnpm install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
-      release-created: ${{ steps.release.outputs.release_created }}
       pr: ${{ steps.release.outputs.pr }}
-      tag-name: ${{ steps.release.outputs.tag_name }}
-      sha: ${{ steps.release.outputs.sha }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
@@ -37,7 +34,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ fromJson(needs.release-please.outputs.pr).headBranchName }}
-      - uses: shiron-dev/actions/setup-node@84397408739dd8be5cab53d443ae764501063dab # v1.6.4
+      - uses: shiron-dev/actions/setup-node@v1.6.5
       - name: Run install
         working-directory: ./matrix-output-write
         run: |
@@ -46,58 +43,37 @@ jobs:
         working-directory: ./matrix-output-write
         run: |
           pnpm run build
-      - name: Commit changes
-        run: |
-          git add -f matrix-output-write/dist
-          if git diff --cached --quiet; then
-            echo "No changes to the output. Exiting."
-            exit 0
-          fi
-          git config --local user.name "github-actions[bot]"
-          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git commit -m "chore: build matrix-output-write"
-          git push
-          echo "Changes committed"
-  update-self-refs:
-    runs-on: ubuntu-latest
-    needs: release-please
-    timeout-minutes: 10
-    if: ${{ needs.release-please.outputs.release-created }}
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-      - name: Bump self references to the released digest
+      - name: Pin self references and commit build
         env:
-          # SHA of the commit that was just released (= the release tag commit).
-          SHA: ${{ needs.release-please.outputs.sha }}
-          TAG: ${{ needs.release-please.outputs.tag-name }}
+          # Release PR title, e.g. "chore(main): release 1.6.6".
+          PR_TITLE: ${{ fromJson(needs.release-please.outputs.pr).title }}
         run: |
           set -euo pipefail
-          if [ -z "${SHA:-}" ] || [ -z "${TAG:-}" ]; then
-            echo "Missing release sha/tag; nothing to do."
-            exit 0
+          VERSION=$(printf '%s' "$PR_TITLE" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+          if [ -z "$VERSION" ]; then
+            echo "Could not determine release version from PR title: $PR_TITLE" >&2
+            exit 1
           fi
-          # Rewrite every `uses: shiron-dev/actions/<action>@<ref> # <ver>` self
-          # reference so it points at the freshly released digest. This breaks the
-          # circular dependency that Renovate cannot resolve on its own.
+          TAG="v$VERSION"
+          # Pin every shiron-dev/actions self reference to the version being
+          # released, inside the release PR, so the released tag is self
+          # consistent (no lag). Releases are immutable, so a version tag is
+          # safe to use without a commit digest.
           grep -rlE 'shiron-dev/actions/[A-Za-z0-9_-]+@' \
             --include='*.yml' --include='*.yaml' . \
             | while read -r f; do
-                SHA="$SHA" TAG="$TAG" perl -0777 -pi -e \
-                  's{(shiron-dev/actions/[A-Za-z0-9_-]+(?:/[A-Za-z0-9_-]+)*)@\S+(?:[ \t]*#[^\n]*)?}{"$1\@$ENV{SHA} # $ENV{TAG}"}ge' \
+                TAG="$TAG" perl -0777 -pi -e \
+                  's{(shiron-dev/actions/[A-Za-z0-9_-]+(?:/[A-Za-z0-9_-]+)*)@\S+(?:[ \t]*#[^\n]*)?}{"$1\@$ENV{TAG}"}ge' \
                   "$f"
               done
-      - name: Commit changes
-        env:
-          TAG: ${{ needs.release-please.outputs.tag-name }}
-        run: |
-          set -euo pipefail
           git add -A
+          git add -f matrix-output-write/dist
           if git diff --cached --quiet; then
-            echo "Self references already up to date. Exiting."
+            echo "Nothing to commit. Exiting."
             exit 0
           fi
           git config --local user.name "github-actions[bot]"
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git commit -m "chore: bump self references to ${TAG}"
+          git commit -m "chore: build matrix-output-write and pin self references to ${TAG}"
           git push
-          echo "Self references updated to ${TAG}"
+          echo "Committed build and self references (${TAG})"

--- a/actions-use-apt-tools/action.yaml
+++ b/actions-use-apt-tools/action.yaml
@@ -84,7 +84,7 @@ runs:
         inputs.method == 'timestamp' &&
         steps.setup.outputs.cache != 'no' &&
         steps.cache.outputs.cache-hit != 'true'
-      uses: shiron-dev/actions/actions-install-and-archive@84397408739dd8be5cab53d443ae764501063dab # v1.6.4
+      uses: shiron-dev/actions/actions-install-and-archive@v1.6.5
       with:
         run: apt-get install -y ${{ inputs.tools }}
         archive: ${{ steps.setup.outputs.archive }}

--- a/github-app-token/action.yml
+++ b/github-app-token/action.yml
@@ -29,7 +29,7 @@ runs:
       env:
         APP_ID: ${{ inputs.app-id }}
         PRIVATE_KEY: ${{ inputs.private-key }}
-    - uses: shiron-dev/actions/post-step@84397408739dd8be5cab53d443ae764501063dab # v1.6.4
+    - uses: shiron-dev/actions/post-step@v1.6.5
       with:
         post: delete.sh
       env:

--- a/renovate-deps-comment/action.yml
+++ b/renovate-deps-comment/action.yml
@@ -19,7 +19,7 @@ runs:
   using: "composite"
   steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-    - uses: shiron-dev/actions/setup-node@84397408739dd8be5cab53d443ae764501063dab # v1.6.4
+    - uses: shiron-dev/actions/setup-node@v1.6.5
       with:
         node-version: "24.11.0"
     - name: Dry-run Renovate


### PR DESCRIPTION
## Summary
リリースをイミュータブルにしたため、self reference（`shiron-dev/actions/*` の自己参照）を commit digest ではなく **リリースバージョンのタグ `@vX.Y.Z`** で固定する方式に変更します。更新は **リリース PR 内**（`build` ジョブ）で行うため、リリースされるタグの中身が自分自身のバージョンと整合し、**1リリース分のラグが解消**されます。

## Changes
- **self reference を `@v1.6.5`（patch まで固定）に変更**
  - `ci.yml`, `release.yml`, `actions-use-apt-tools`, `github-app-token`, `renovate-deps-comment`
  - digest + `# vX.Y.Z` コメント形式を廃止
- **`release.yml`**
  - `build` ジョブ（リリース PR ブランチ上で動作）で、PR タイトルから今切るバージョンを取得し、全 self reference を `@vX.Y.Z` に書き換えて dist と一緒にコミット
  - リリース後に main へ直 push していた `update-self-refs` ジョブを削除（保護された main へ push できず実質機能していなかった）
  - 不要になった `release-created` / `tag-name` / `sha` outputs を削除
- **`renovate.json`**
  - `shiron-dev/actions` を Renovate 管理外にする理由を新方式に合わせて更新（リリースワークフローがタグ参照を管理。意図的に digest pin しない）
  - 第三者アクションへの `pinDigests: true` は維持

## Why no digest for self references
self reference は同一リポジトリ内の参照であり、タグを動かせる主体はコード自体を書き換えられる主体と同一なので、digest pin の追加的なセキュリティ価値はほぼありません。さらにリリースがイミュータブルなのでバージョンタグの付け替えも起きません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FjtQsZEfN13u8Cz3ZT82yT)_

--- commit logs ---
* ci(release): pin self references to the version tag in the release PR
Releases are now immutable, so self references no longer need a commit
digest. Switch every shiron-dev/actions self reference to the released
version tag (@vX.Y.Z) and pin it inside the release PR's build job, so the
released tag is self consistent with no one-release lag and without an
extra post-release commit to main. The post-release update-self-refs job
(which also could not push to protected main) is removed.

Renovate keeps ignoring shiron-dev/actions (now because the release
workflow owns these tag refs, and they are intentionally not digest
pinned); digest pinning still applies to third-party actions.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FjtQsZEfN13u8Cz3ZT82yT


