### PR TITLE
fix: use local action refs in workflows so the release build can push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
         working-directory: ./matrix-output-write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-      - uses: shiron-dev/actions/setup-node@v1.6.5
+      - uses: ./setup-node
       - name: Run install
         run: |
           pnpm install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ fromJson(needs.release-please.outputs.pr).headBranchName }}
-      - uses: shiron-dev/actions/setup-node@v1.6.5
+      - uses: ./setup-node
       - name: Run install
         working-directory: ./matrix-output-write
         run: |
@@ -59,8 +59,11 @@ jobs:
           # released, inside the release PR, so the released tag is self
           # consistent (no lag). Releases are immutable, so a version tag is
           # safe to use without a commit digest.
+          # Scope to composite action manifests only: GITHUB_TOKEN cannot push
+          # changes under .github/workflows/ (needs the `workflows` permission),
+          # and workflows reference the local actions with `./` anyway.
           grep -rlE 'shiron-dev/actions/[A-Za-z0-9_-]+@' \
-            --include='*.yml' --include='*.yaml' . \
+            --include='action.yml' --include='action.yaml' . \
             | while read -r f; do
                 TAG="$TAG" perl -0777 -pi -e \
                   's{(shiron-dev/actions/[A-Za-z0-9_-]+(?:/[A-Za-z0-9_-]+)*)@\S+(?:[ \t]*#[^\n]*)?}{"$1\@$ENV{TAG}"}ge' \


### PR DESCRIPTION
## 背景（PR #404 が動いていなかった原因）
PR #403 マージ後の Release ワークフロー（build ジョブ）は self reference を `@v1.7.0` に書き換えてコミットまで成功していましたが、**push が拒否**されていました:

```
! [remote rejected] release-please--branches--main
(refusing to allow a GitHub App to create or update workflow `.github/workflows/ci.yml`
 without `workflows` permission)
```

`GITHUB_TOKEN` は `.github/workflows/` 配下のファイル変更を push できません（特殊な `workflows` 権限が必要で、workflow の `permissions:` では付与不可）。self-ref 書き換えが `ci.yml` / `release.yml` に触れたため push 全体が失敗し、release PR #404 には dist も self-ref 更新も入りませんでした。

## 修正
- **ワークフロー内の self reference をローカル参照 `./setup-node` に変更**（`ci.yml` の matrix-output-write-test、`release.yml` の build）。既存の `./post-step` / `./renovate-deps-comment` 等と同じ慣習で、自リポ CI が自リポの action を使う正しい形。
- これで build ジョブが書き換えるのは **公開 composite action の `action.yml`/`action.yaml` のみ**になり、`GITHUB_TOKEN` で push 可能に。書き換え対象の grep もその範囲にスコープ。

公開アクション同士の参照（actions-use-apt-tools → actions-install-and-archive など）は relative 参照不可なので `@vX.Y.Z` のまま、これは build ジョブが更新します。

## 効果
このPRをマージすると Release ワークフローが再度走り、build ジョブが（ワークフローファイルに触れずに）composite action の self-ref を当該リリースバージョンへ書き換え＋dist を release PR ブランチへ push できるようになり、#404 の release PR が正しく更新されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FjtQsZEfN13u8Cz3ZT82yT)_

--- commit logs ---
* fix(release): use local action refs in workflows so the release build can push
The release build job rewrites self references and pushes them to the
release PR branch, but GITHUB_TOKEN is not allowed to push changes under
.github/workflows/ (that needs the special `workflows` permission). Because
the rewrite touched ci.yml and release.yml, the whole push was rejected and
the release PR got neither the rebuilt dist nor the pinned self references.

Workflows now reference the in-repo actions locally (./setup-node), matching
the existing convention (./post-step, ./renovate-deps-comment, ...), so the
build job only ever rewrites composite action manifests (action.yml/.yaml),
which GITHUB_TOKEN can push. The self-ref rewrite is scoped accordingly.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FjtQsZEfN13u8Cz3ZT82yT


